### PR TITLE
Add kanbn tasks; make build.sh resolve dotnet

### DIFF
--- a/.kanbn/index.md
+++ b/.kanbn/index.md
@@ -1,0 +1,20 @@
+---
+startedColumns:
+  - 'In Progress'
+completedColumns:
+  - Done
+---
+
+# PCTama
+
+## Backlog
+
+- [actor-display](tasks/actor-display.md)
+- [controller-logic](tasks/controller-logic.md)
+- [text-input](tasks/text-input.md)
+
+## Todo
+
+## In Progress
+
+## Done

--- a/.kanbn/tasks/actor-display.md
+++ b/.kanbn/tasks/actor-display.md
@@ -1,0 +1,11 @@
+---
+created: 2026-02-15T02:09:52.983Z
+updated: 2026-02-15T02:09:52.980Z
+assigned: ""
+progress: 0
+tags: []
+---
+
+# Actor Display
+
+Make sure the actor can display text or an avatar at the very least.

--- a/.kanbn/tasks/controller-logic.md
+++ b/.kanbn/tasks/controller-logic.md
@@ -1,0 +1,11 @@
+---
+created: 2026-02-15T02:10:39.474Z
+updated: 2026-02-15T02:10:39.472Z
+assigned: ""
+progress: 0
+tags: []
+---
+
+# Controller Logic
+
+Update the controller to support custom prompts/behavior when using the input MCP data to direct the actor.

--- a/.kanbn/tasks/text-input.md
+++ b/.kanbn/tasks/text-input.md
@@ -1,0 +1,11 @@
+---
+created: 2026-02-15T02:12:09.324Z
+updated: 2026-02-15T02:12:09.322Z
+assigned: ""
+progress: 0
+tags: []
+---
+
+# Text input
+
+Setup and test the text input from OBS LocalVoice to the Text input controller.


### PR DESCRIPTION
Add a Kanban board (.kanbn/index.md) and three backlog task files (actor-display, controller-logic, text-input). Revamp build.sh to robustly locate the dotnet executable: introduce resolve_dotnet and DOTNET_CMD, probe DOTNET_ROOT, PATH, and several common candidate locations, prepend dotnet's directory to PATH on macOS, call resolve_dotnet before invoking dotnet in build/restore/test/clean/run, and emit a clear error if dotnet is not found; the app run now uses "$DOTNET_CMD" run --no-build.