### PR TITLE
Mark text-input as In Progress

### DIFF
--- a/.kanbn/index.md
+++ b/.kanbn/index.md
@@ -11,10 +11,11 @@ completedColumns:
 
 - [actor-display](tasks/actor-display.md)
 - [controller-logic](tasks/controller-logic.md)
-- [text-input](tasks/text-input.md)
 
 ## Todo
 
 ## In Progress
+
+- [text-input](tasks/text-input.md)
 
 ## Done

--- a/.kanbn/tasks/text-input.md
+++ b/.kanbn/tasks/text-input.md
@@ -1,9 +1,10 @@
 ---
 created: 2026-02-15T02:12:09.324Z
-updated: 2026-02-15T02:12:09.322Z
+updated: 2026-02-15T02:21:13.219Z
 assigned: ""
 progress: 0
 tags: []
+started: 2026-02-15T02:21:13.219Z
 ---
 
 # Text input


### PR DESCRIPTION
Move the text-input task from the Todo column to In Progress in .kanbn/index.md. Update the task metadata in .kanbn/tasks/text-input.md by refreshing the updated timestamp and adding a started timestamp to indicate work has begun.