### PR TITLE
Add personality profiles and active personality support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![Build and Test](https://github.com/yourusername/PCTama/workflows/PCTama%20Build%20and%20Test/badge.svg)](https://github.com/yourusername/PCTama/actions)
 [![CMake Build](https://github.com/yourusername/PCTama/workflows/CMake%20Build/badge.svg)](https://github.com/yourusername/PCTama/actions)
 
-A sophisticated microservices-based desktop pet application that integrates AI to enable intelligent interactions. Built with ASP.NET Core, .NET Aspire framework, and Model Context Protocol (MCP) integration, PCTama uses local LLMs to process streaming text input and provides interactive visual output via WinUI3.
+A sophisticated microservices-based desktop pet application that integrates AI to enable intelligent interactions. Built with ASP.NET Core, .NET Aspire framework, and Model Context Protocol (MCP) integration, PCTama uses local LLMs to process streaming text input and provides interactive visual output via Avalonia UI.
 
 ## 🎯 Project Goals
 
 - ✅ **Aspire-based microservices** - Cloud-native architecture with service discovery
 - ✅ **MCP integration ready** - Framework for Model Context Protocol implementation
 - ✅ **Streaming text input** - Real-time text processing from multiple sources
-- ✅ **Desktop pet display** - WinUI3-based output with actions and animations
+- ✅ **Desktop pet display** - Avalonia UI-based output with actions and animations
 - ✅ **Extensible design** - Easy to add new input/output MCPs
 - ✅ **Cross-platform builds** - CMake support for Windows, macOS, and Linux
 
@@ -44,9 +44,9 @@ PCTama is built as a collection of ASP.NET microservices orchestrated through .N
          ▼                    ▼                   ▼
 ┌────────────────┐   ┌────────────────┐   ┌────────────────┐
 │   Text MCP     │   │   Controller   │   │   Actor MCP    │
-│   (Port 5001)  │──>│   (Port 5000)  │──>│   (Port 5002)  │
+│   (Port 5001)  │──>│   (Port 5003)  │──>│   (Port 5000)  │
 │                │   │                │   │                │
-│ • OBS LocalVoice   │ • MCP SDK      │   │ • WinUI3       │
+│ • OBS LocalVoice   │ • MCP SDK      │   │ • Avalonia UI  │
 │ • Text Stream      │ • Local LLM    │   │ • Actions      │
 │ • Buffering        │ • Orchestration│   │ • Display      │
 └────────────────┘   └────────────────┘   └────────────────┘
@@ -65,7 +65,7 @@ PCTama is built as a collection of ASP.NET microservices orchestrated through .N
   - Multiple input source support
   
 - **PCTama.ActorMCP** (port 5002) - Desktop pet display
-  - WinUI3-based window management
+  - Avalonia UI-based window management
   - Action queue processing
   - Animation support
   
@@ -84,7 +84,7 @@ PCTama is built as a collection of ASP.NET microservices orchestrated through .N
 - **OpenTelemetry** - Built-in observability dashboard
 - **Health Checks** - Service monitoring and status endpoints
 - **Extensible Config** - Add new MCPs and input sources easily
-- **WinUI3 Display** - Modern Windows UI framework
+- **Avalonia UI Display** - Cross-platform UI framework
 - **REST APIs** - Comprehensive endpoints for all services
 - **Full Testing** - xUnit suite with unit & integration tests
 - **CI/CD** - GitHub Actions multi-platform builds
@@ -95,7 +95,7 @@ PCTama is built as a collection of ASP.NET microservices orchestrated through .N
 - **.NET 8.0 SDK** or later ([download](https://dotnet.microsoft.com/download))
 - **CMake** 3.20 or later
 - **Git** for version control
-- **Windows 10 Build 19041+** (for ActorMCP/WinUI3 only)
+- **Windows 10 Build 19041+** (for ActorMCP/Avalonia UI only)
 
 ### Optional
 - **Ollama** or local LLM for AI responses
@@ -265,7 +265,7 @@ Edit `src/PCTama.ActorMCP/appsettings.json`:
 ```json
 {
   "ActorMcpConfiguration": {
-    "DisplayType": "WinUI3",
+    "DisplayType": "Avalonia UI",
     "WindowWidth": 400,
     "WindowHeight": 300,
     "WindowTitle": "PCTama Actor",
@@ -288,7 +288,7 @@ brew install ollama              # macOS
 ollama serve
 
 # In another terminal, pull a model
-ollama pull llama2
+ollama pull qwen2.5:3b
 
 # Verify it's running
 curl http://localhost:11434/api/tags
@@ -395,7 +395,7 @@ PCTama/
 │   ├── PCTama.ServiceDefaults/ # Shared configuration
 │   ├── PCTama.Controller/      # Main controller service
 │   ├── PCTama.TextMCP/         # Text input service
-│   └── PCTama.ActorMCP/        # WinUI3 output service
+│   └── PCTama.ActorMCP/        # Avalonia UI output service
 ├── tests/
 │   └── PCTama.Tests/           # Unit & integration tests
 ├── build.sh                    # macOS/Linux build script

--- a/src/PCTama.ActorMCP/Controllers/ActorController.cs
+++ b/src/PCTama.ActorMCP/Controllers/ActorController.cs
@@ -85,4 +85,60 @@ public class ActorController : ControllerBase
     {
         return Ok(new { status = "healthy", timestamp = DateTime.UtcNow });
     }
+
+    // MCP Tool Discovery
+    [HttpGet("mcp/tools")]
+    public IActionResult GetMcpTools()
+    {
+        var actorService = GetActorService();
+        if (actorService == null)
+        {
+            return StatusCode(503, new { error = "Actor service not initialized" });
+        }
+
+        var tools = actorService.GetAvailableTools();
+        return Ok(new McpToolsResponse { Tools = tools });
+    }
+
+    // MCP Resource Discovery
+    [HttpGet("mcp/resources")]
+    public IActionResult GetMcpResources()
+    {
+        var actorService = GetActorService();
+        if (actorService == null)
+        {
+            return StatusCode(503, new { error = "Actor service not initialized" });
+        }
+
+        var resources = actorService.GetAvailableResources();
+        return Ok(new McpResourcesResponse { Resources = resources });
+    }
+
+    // MCP Resource Access
+    [HttpGet("mcp/resources/{resourceId}")]
+    public IActionResult GetMcpResource(string resourceId)
+    {
+        var actorService = GetActorService();
+        if (actorService == null)
+        {
+            return StatusCode(503, new { error = "Actor service not initialized" });
+        }
+
+        switch (resourceId.ToLower())
+        {
+            case "state":
+                var state = actorService.GetState();
+                return Ok(state);
+
+            case "queue":
+                return Ok(new
+                {
+                    queueDepth = actorService.GetQueueCount(),
+                    timestamp = DateTime.UtcNow
+                });
+
+            default:
+                return NotFound(new { error = $"Resource '{resourceId}' not found" });
+        }
+    }
 }

--- a/src/PCTama.ActorMCP/Models/ActorConfiguration.cs
+++ b/src/PCTama.ActorMCP/Models/ActorConfiguration.cs
@@ -26,3 +26,39 @@ public class ActionResult
     public string Message { get; set; } = string.Empty;
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 }
+// MCP Tool Models
+public class McpTool
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public object InputSchema { get; set; } = new { };
+}
+
+public class McpToolsResponse
+{
+    public List<McpTool> Tools { get; set; } = new();
+}
+
+// MCP Resource Models
+public class ActorStateResource
+{
+    public string CurrentState { get; set; } = string.Empty;
+    public int QueueDepth { get; set; }
+    public string? LastAction { get; set; }
+    public DateTime? LastActionTimestamp { get; set; }
+    public int TotalActionsProcessed { get; set; }
+    public DateTime ServiceStartTime { get; set; }
+}
+
+public class McpResource
+{
+    public string Uri { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string MimeType { get; set; } = "application/json";
+}
+
+public class McpResourcesResponse
+{
+    public List<McpResource> Resources { get; set; } = new();
+}

--- a/src/PCTama.Controller/Models/McpConfiguration.cs
+++ b/src/PCTama.Controller/Models/McpConfiguration.cs
@@ -27,6 +27,15 @@ public class PromptConfiguration
     public Dictionary<string, string> ResponsePatterns { get; set; } = new();
 }
 
+public class PersonalityProfile
+{
+    public string Name { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string SystemPrompt { get; set; } = string.Empty;
+    public List<string> Examples { get; set; } = new();
+}
+
 public class ActionMapping
 {
     public string Pattern { get; set; } = string.Empty;
@@ -43,6 +52,8 @@ public class McpConfiguration
     public PromptConfiguration PromptConfig { get; set; } = new();
     public List<BehaviorRule> BehaviorRules { get; set; } = new();
     public List<ActionMapping> ActionMappings { get; set; } = new();
+    public List<PersonalityProfile> Personalities { get; set; } = new();
+    public string ActivePersonality { get; set; } = "default";
     public int ProcessingIntervalMs { get; set; } = 1000;
     public bool UseChatMode { get; set; } = true;
     public int MaxChatHistory { get; set; } = 10;

--- a/src/PCTama.Controller/appsettings.json
+++ b/src/PCTama.Controller/appsettings.json
@@ -49,6 +49,75 @@
         "Enabled": true
       }
     ],
+    "Personalities": [
+      {
+        "Name": "default",
+        "DisplayName": "Helpful Assistant",
+        "Description": "Balanced, friendly, and helpful",
+        "SystemPrompt": "You are PCTama, a helpful desktop pet assistant. You respond to user input with short, friendly messages. Your responses should be concise (1-2 sentences) and appropriate for display in a small desktop window. When you want to perform an action, describe it naturally in your response.",
+        "Examples": [
+          "User: Hello! -> PCTama: Hi there! I'm here to help!",
+          "User: What time is it? -> PCTama: Let me check the time for you!",
+          "User: Thanks! -> PCTama: You're welcome! Happy to help!"
+        ]
+      },
+      {
+        "Name": "cheerful",
+        "DisplayName": "Cheerful Friend",
+        "Description": "Enthusiastic, upbeat, and encouraging",
+        "SystemPrompt": "You are PCTama, an enthusiastic and cheerful desktop companion! You're always excited to help and love spreading positivity. Respond with energy and warmth in 1-2 short sentences. Use enthusiastic language and be super encouraging!",
+        "Examples": [
+          "User: Hello! -> PCTama: Hey there, friend! So happy to see you!",
+          "User: I'm working on a project -> PCTama: That's awesome! You're going to do great!",
+          "User: Thanks! -> PCTama: Yay! Anytime, happy to help!"
+        ]
+      },
+      {
+        "Name": "professional",
+        "DisplayName": "Professional Assistant",
+        "Description": "Formal, concise, and efficient",
+        "SystemPrompt": "You are PCTama, a professional desktop assistant. Provide clear, concise, and formal responses. Keep answers brief (1-2 sentences) and focused on efficiency. Maintain a polite but business-like tone.",
+        "Examples": [
+          "User: Hello! -> PCTama: Good day. How may I assist you?",
+          "User: What's the status? -> PCTama: Processing your request now.",
+          "User: Thanks! -> PCTama: You're welcome. Let me know if you need anything else."
+        ]
+      },
+      {
+        "Name": "playful",
+        "DisplayName": "Playful Companion",
+        "Description": "Fun, casual, and lighthearted",
+        "SystemPrompt": "You are PCTama, a playful and fun desktop buddy! You love jokes, casual language, and keeping things light. Respond in a friendly, relaxed way with 1-2 sentences. Be creative and don't take things too seriously!",
+        "Examples": [
+          "User: Hello! -> PCTama: Heya! What's cookin'?",
+          "User: I'm bored -> PCTama: Same! Wanna see me do a virtual backflip?",
+          "User: Thanks! -> PCTama: No prob, buddy! That's what I'm here for!"
+        ]
+      },
+      {
+        "Name": "calm",
+        "DisplayName": "Calm Presence",
+        "Description": "Peaceful, zen, and soothing",
+        "SystemPrompt": "You are PCTama, a calm and peaceful desktop companion. Speak with serenity and mindfulness. Keep responses gentle and brief (1-2 sentences). Your presence should be soothing and reassuring, like a peaceful moment in a busy day.",
+        "Examples": [
+          "User: Hello! -> PCTama: Hello. Take a breath and relax for a moment.",
+          "User: I'm stressed -> PCTama: Everything will be okay. One step at a time.",
+          "User: Thanks! -> PCTama: You're welcome. Peace be with you."
+        ]
+      },
+      {
+        "Name": "technical",
+        "DisplayName": "Technical Assistant",
+        "Description": "Keyword-focused, minimal, technical responses",
+        "SystemPrompt": "You are PCTama, a technical assistant. Extract key terms from user input and respond with minimal, concise technical information. Focus on keywords and provide direct answers only. Use technical terminology. Maximum 1 sentence or a few words. No fluff.",
+        "Examples": [
+          "User: What's the CPU usage? -> PCTama: CPU: 45%",
+          "User: Check disk space -> PCTama: Disk: 256GB available",
+          "User: Thanks! -> PCTama: Acknowledged."
+        ]
+      }
+    ],
+    "ActivePersonality": "default",
     "ActionMappings": [
       {
         "Pattern": "(dance|celebrate|party)",

--- a/src/PCTama.TextMCP/Controllers/TextController.cs
+++ b/src/PCTama.TextMCP/Controllers/TextController.cs
@@ -55,4 +55,42 @@ public class TextController : ControllerBase
     {
         return Ok(new { status = "healthy", timestamp = DateTime.UtcNow });
     }
-}
+
+    // MCP Tool Discovery
+    [HttpGet("mcp/tools")]
+    public IActionResult GetMcpTools()
+    {
+        var tools = _textStreamService.GetAvailableTools();
+        return Ok(new McpToolsResponse { Tools = tools });
+    }
+
+    // MCP Resource Discovery
+    [HttpGet("mcp/resources")]
+    public IActionResult GetMcpResources()
+    {
+        var resources = _textStreamService.GetAvailableResources();
+        return Ok(new McpResourcesResponse { Resources = resources });
+    }
+
+    // MCP Resource Access
+    [HttpGet("mcp/resources/{resourceId}")]
+    public async Task<IActionResult> GetMcpResource(string resourceId)
+    {
+        switch (resourceId.ToLower())
+        {
+            case "state":
+                var state = _textStreamService.GetState();
+                return Ok(state);
+
+            case "buffer":
+                var buffer = await _textStreamService.GetAllTextAsync();
+                return Ok(buffer);
+
+            case "latest":
+                var latest = await _textStreamService.GetLatestTextAsync();
+                return Ok(latest);
+
+            default:
+                return NotFound(new { error = $"Resource '{resourceId}' not found" });
+        }
+    }}

--- a/src/PCTama.TextMCP/Models/TextStreamConfiguration.cs
+++ b/src/PCTama.TextMCP/Models/TextStreamConfiguration.cs
@@ -36,3 +36,40 @@ public class SrtCaption
     public string Text { get; set; } = string.Empty;
     public DateTime ParsedAt { get; set; } = DateTime.UtcNow;
 }
+// MCP Tool Models
+public class McpTool
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public object InputSchema { get; set; } = new { };
+}
+
+public class McpToolsResponse
+{
+    public List<McpTool> Tools { get; set; } = new();
+}
+
+// MCP Resource Models
+public class TextStreamStateResource
+{
+    public string CurrentState { get; set; } = string.Empty;
+    public int BufferCount { get; set; }
+    public DateTime? LastTextTimestamp { get; set; }
+    public string ActiveSource { get; set; } = string.Empty;
+    public List<string> ActiveSources { get; set; } = new();
+    public int TotalTextsProcessed { get; set; }
+    public DateTime ServiceStartTime { get; set; }
+}
+
+public class McpResource
+{
+    public string Uri { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string MimeType { get; set; } = "application/json";
+}
+
+public class McpResourcesResponse
+{
+    public List<McpResource> Resources { get; set; } = new();
+}


### PR DESCRIPTION
Introduce PersonalityProfile and wire personality support into MCP flow: add Personalities list and ActivePersonality to McpConfiguration, and include example personalities in appsettings.json. McpClientService now logs the active personality, exposes GetActivePersonality and GetSystemPrompt helpers, and uses the selected personality's SystemPrompt (falling back to PromptConfig.SystemPrompt) when building chat/generate requests. This enables switching agent tone/behavior via configuration.